### PR TITLE
Fix gem name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install
 Add this line to your Gemfile:
 
 ```
-  gem 'shippo-ruby'
+  gem 'shippo'
 ```
 
 The gems you'll need are:


### PR DESCRIPTION
* The actual gem name is just "shippo". The instructions as stated do
  not work.