### PR TITLE
Expose backend errors in the APIServerException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ test/version_tmp
 tmp
 vendor/
 **/.DS_Store
-
 .idea/

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'codeclimate-test-reporter', group: :test, require: nil
 
 # Specify your gem's dependencies in counter-cache.gemspec
 gemspec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'bundler/setup'
+require 'shippo'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start

--- a/bin/example
+++ b/bin/example
@@ -22,7 +22,6 @@ require 'awesome_print'
 require 'json'
 
 Shippo::API.token = ENV['SHIPPO_TOKEN']
-Shippo::API.debug = false # set to true for debugging output
 
 # Simple wrapper class to help us print objects to the STDOUT
 class ExampleHelper
@@ -32,12 +31,11 @@ class ExampleHelper
     puts 'OK'
     result
   rescue Exception => e
-    puts 'ERROR'
     raise(e)
   end
 
   def self.dump_object(instance, msg = nil)
-    return unless ENV['SHIPPO_DEBUG']
+    return unless Shippo::API.debug?
     sep
     puts "#{msg.upcase}:" if msg
     puts "\#<#{instance.class.inspect}:0x#{instance.object_id.to_s(16)}> ⇒ "
@@ -101,7 +99,7 @@ begin
     file.puts JSON.dump(shipment.to_hash)
   end
 rescue Shippo::Exceptions::APIServerError => e
-  puts "Server returned an error:\n#{e.inspect}"
+  puts "Server returned an error:\n#{e}"
   exit 3
 rescue Shippo::Exceptions::ConnectionError
   puts 'Error connecting to remote host. Is your Internet working?'

--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -38,7 +38,7 @@ module Shippo
       end
 
       def debug?
-        Shippo::API.debug
+        self.debug
       end
     end
   end

--- a/lib/shippo/api/version.rb
+++ b/lib/shippo/api/version.rb
@@ -1,5 +1,5 @@
 module Shippo
   module API
-    VERSION = '2.0.2'
+    VERSION = '2.0.3'
   end
 end

--- a/lib/shippo/exceptions.rb
+++ b/lib/shippo/exceptions.rb
@@ -1,7 +1,8 @@
-module Shippo
-  module Exceptions
-  end
-end
-
 require 'shippo/exceptions/error'
-Dir[File.dirname(__FILE__) + '/exceptions/*.rb'].each {|file| require file }
+require 'shippo/exceptions/api_error'
+require 'shippo/exceptions/api_server_error'
+
+class Shippo::Exceptions::ConnectionError < Shippo::Exceptions::Error; end
+class Shippo::Exceptions::AuthenticationError < Shippo::Exceptions::Error; end
+class Shippo::Exceptions::MissingDataError < Shippo::Exceptions::Error; end
+class Shippo::Exceptions::AbstractClassInitError < Shippo::Exceptions::Error; end

--- a/lib/shippo/exceptions/api_error.rb
+++ b/lib/shippo/exceptions/api_error.rb
@@ -1,20 +1,35 @@
-class Shippo::Exceptions::APIError < ::Shippo::Exceptions::Error
-  attr_accessor :message, :req
-  def initialize(message = nil, req = nil)
-    super(message)
-    self.req = req
-  end
+module Shippo
+  module Exceptions
+    class APIError < ::Shippo::Exceptions::Error
+      attr_accessor :request,
+                    :response,
+                    :http_response_message
 
-  def to_s
-    "#{self.class.name} ⇨ #{req.url}#{response} ⇨ #{message}"
-  end
 
-  def response
-    req.response && req.response.http_code ? "[ ⇨ HTTP #{req.response.http_code} ]" : ''
+      def initialize(message = nil,
+                     request = nil,
+                     response = nil)
+        super(message)
+        self.request  = request
+        self.response = response
+      end
+
+      def to_s_members
+        super + %i(server_url response)
+      end
+
+      def server_url
+        @server_url ||= (request ? request.url : '')
+      end
+    end
   end
 end
 
-class Shippo::Exceptions::UnsuccessfulResponseError < Shippo::Exceptions::APIError; end
-class Shippo::Exceptions::APIServerError < Shippo::Exceptions::APIError; end
-class Shippo::Exceptions::InvalidCategoryValueError < Shippo::Exceptions::APIError; end
+
+class Shippo::Exceptions::UnsuccessfulResponseError < Shippo::Exceptions::APIError;
+end
+class Shippo::Exceptions::InvalidCategoryValueError < Shippo::Exceptions::APIError;
+end
+class Shippo::Exceptions::InvalidJsonError < Shippo::Exceptions::APIError;
+end
 

--- a/lib/shippo/exceptions/api_server_error.rb
+++ b/lib/shippo/exceptions/api_server_error.rb
@@ -1,0 +1,25 @@
+require 'shippo/exceptions/api_error'
+
+module Shippo
+  module Exceptions
+    #
+    # The +APIServerError+ happens when the server returns a parseable JSON response,
+    # but when such response indicates a failed operation due to either
+    # validation or other business, data or logic issues.
+    #
+    # The error adds the HTTP response message member, which would typically be
+    # "400 Bad Request"
+    #
+    class APIServerError < APIError
+
+      def initialize(message = nil, request = nil, response = nil, http_response_message = nil)
+        super(message, request, response)
+        self.http_response_message = http_response_message
+      end
+
+      def to_s_members
+        %i(http_response_message) + super
+      end
+    end
+  end
+end

--- a/lib/shippo/exceptions/error.rb
+++ b/lib/shippo/exceptions/error.rb
@@ -1,22 +1,45 @@
-class Shippo::Exceptions::Error < StandardError
-  attr_accessor :message
+module Shippo
+  module Exceptions
 
-  def initialize(thing = nil)
-    if thing.is_a?(String)
-      self.message = thing
-    elsif thing.respond_to?(:message)
-      self.message = thing.message
-    else
-      super(thing)
+    class Error < StandardError
+      attr_accessor :message
+
+      def initialize(thing = nil)
+        if thing.is_a?(String)
+          self.message = thing
+        elsif thing.respond_to?(:message)
+          self.message = thing.message
+        else
+          super(thing)
+        end
+      end
+
+      def to_s_members
+        %i()
+      end
+
+      def to_s
+        out = super
+        out << " (#{message}) " if message
+        to_s_members.each do |member|
+          out << member_to_s(member)
+        end
+        out
+      end
+
+      private
+
+      def member_to_s(member)
+        out   = ''
+        value = self.send(member)
+        out << "\n#{sprintf('%21s', member)}: '#{value}', " if value && (value != '')
+        out
+      end
+
+
     end
-  end
 
-  def to_s
-    "BOOM! ⇨ #{message}"
+
+
   end
 end
-
-class Shippo::Exceptions::ConnectionError < Shippo::Exceptions::Error; end
-class Shippo::Exceptions::AuthenticationError < Shippo::Exceptions::Error; end
-class Shippo::Exceptions::MissingDataError < Shippo::Exceptions::Error; end
-class Shippo::Exceptions::AbstractClassInitError < Shippo::Exceptions::Error; end

--- a/spec/shippo/api/request_spec.rb
+++ b/spec/shippo/api/request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Shippo::API::Request' do
+RSpec.describe Shippo::API::Request do
 
   let(:json_string) { File.read('spec/fixtures/parcel_list.json') }
   let(:json) { JSON.parse(json_string, { symbolize_names: true }) }
@@ -11,8 +11,10 @@ RSpec.describe 'Shippo::API::Request' do
 
   let(:api_request) { Shippo::API::Request.new(method: method, uri: uri, params: params, headers: headers) }
   let(:http_response) { RestClient::Response.create(json_string, 200, {}, { response: 'OK' }) }
+
   context '#new' do
     before do
+
       expect(RestClient::Request).to receive(:execute).and_return(http_response)
       api_request.execute
     end
@@ -26,4 +28,5 @@ RSpec.describe 'Shippo::API::Request' do
       expect(api_request.parsed_response).to eql(json.to_hash)
     end
   end
+
 end

--- a/spec/shippo/exceptions/api_server_error_spec.rb
+++ b/spec/shippo/exceptions/api_server_error_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+module Shippo
+  module Exceptions
+
+    RSpec.describe APIServerError do
+      let(:http_response) { '401 Super Bad' }
+
+      let(:response) {
+        %q={"address_from": [{"country": ["Invalid value specified for country 'USSSSSS'"]}]}=
+      }
+
+      let(:request) {
+        ::Shippo::API::Request.new(
+          method: :get,
+          uri:    '/address',
+          params: { object_id: 1 })
+      }
+
+      let(:error) { APIServerError.new('Bad things are happening',
+                                       request, response, http_response) }
+
+      context '#new' do
+        it 'should have all members set' do
+          expect(error.request).to eql(request)
+          expect(error.response).to eql(response)
+          expect(error.http_response_message).to eql(http_response)
+        end
+      end
+
+      context '#to_s' do
+        context 'should include both subclass and superclass members' do
+          subject { error.to_s }
+          it { is_expected.to_not be_nil }
+          it { is_expected.to match /response:/m}
+          it { is_expected.to match /401 Super Bad/m}
+          it { is_expected.to match /http_response_message:/m}
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
* [fixes #22](https://github.com/goshippo/shippo-ruby-client/issues/22)
* The details of the error were in the response object, which is only accessible via the exception thrown by the RestClient library.
* reorganizing exceptions to enable subclassing with additional parameters and more readable `#to_s` method
* adding `bin/console` for easy irb-ing
* version bump to `2.0.3`