### PR TITLE
Rails5 Compatibility via relaxed dependencies

### DIFF
--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -33,7 +33,7 @@ module Shippo
       %i[get put post].each do |method|
         define_method method do |*args|
           uri, params, headers = *args
-          request(method, uri, params || {}, headers || {})
+          self.request(method, uri, params || {}, headers || {})
         end
       end
 

--- a/lib/shippo/api/version.rb
+++ b/lib/shippo/api/version.rb
@@ -1,5 +1,5 @@
 module Shippo
   module API
-    VERSION = '2.0.2'
+    VERSION = '2.0.4'
   end
 end

--- a/shippo.gemspec
+++ b/shippo.gemspec
@@ -17,10 +17,9 @@ Gem::Specification.new do |spec|
   spec.metadata              = { 'shippo_documentation' => 'https://goshippo.com/docs/' }
 
   spec.add_dependency 'rest-client', '~> 1.8'
-  spec.add_dependency 'mime-types', '~> 2'
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'hashie', '~> 3.4'
-  spec.add_dependency 'activesupport', '~> 4'
+  spec.add_dependency 'activesupport', '>= 4'
   spec.add_dependency 'awesome_print'
 
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
- removing mime-types dependency 
- relaxing activesupport to allow version 5
- keeping rest-client (the culprit) still at version 1.8 as 2.0
   contains backward incompatible changes.
- [fixes #21](https://github.com/goshippo/shippo-ruby-client/issues/21)