### PR TITLE
added version as a possible header. also updated README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2.0.5 release, Oct 24th, 2016
+ - Updated README.md
+ - now possible to send API version
 #### 2.0.4 release, Oct 6th 2016
  - Rails5 Compatibility via relaxed dependencies
    - removing mime-types dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
+#### 2.0.4 release, Oct 6th 2016
+ - Rails5 Compatibility via relaxed dependencies
+   - removing mime-types dependency
+   - relaxing activesupport to allow version 5
+ - reorganizing exceptions to enable subclassing with additional parameters and more readable #to_s method
+ - adding bin/console for easy irb-ing 
+
 #### 2.0.3 release, Oct 3rd 2016
 
- * Handled RestClient::BadRequest to show response content
+ - Handled RestClient::BadRequest to show response content
 
 #### 2.0.2 release, Aug 17th 2016
 
- * Removed gem dependency `colored2` as directly decorating object and string was causing Rals Rack to throw errors when users uploaded large files.
- * Fixed url for `CarrierAccount` 
- * README fixes
+ - Removed gem dependency `colored2` as directly decorating object and string was causing Rals Rack to throw errors when users uploaded large files.
+ - Fixed url for `CarrierAccount` 
+ - README fixes
  
 #### 2.0.0-beta  July 7th, 2016
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Below we demonstrate the most basic usage of the library:
 require 'shippo'
 
 # Setup your API token
-Shippo.api_key = 'aff988f77afa0fdfdfadf'  # not an actual valid token
+Shippo::API.token = 'aff988f77afa0fdfdfadf'  # not an actual valid token
 
 # Setup query parameter hash
 params   = { object_purpose: 'PURCHASE',

--- a/lib/shippo.rb
+++ b/lib/shippo.rb
@@ -1,4 +1,4 @@
-#
+VERSION = '2.0.5'#
 # +Shippo+ is the ruby module enclosing all and any ruby-based
 # functionality developed by Shippo, Inc.
 #

--- a/lib/shippo.rb
+++ b/lib/shippo.rb
@@ -1,4 +1,4 @@
-VERSION = '2.0.5'#
+#
 # +Shippo+ is the ruby module enclosing all and any ruby-based
 # functionality developed by Shippo, Inc.
 #

--- a/lib/shippo.rb
+++ b/lib/shippo.rb
@@ -18,7 +18,11 @@ module Shippo
   def self.api_key(value)
     ::Shippo::API.token = value
   end
+  def self.api_version(value)
+    ::Shippo::API.version = value
+  end
   class << self
+    alias_method :api_version=, :api_version
     alias_method :api_key=, :api_key
     alias_method :api_token=, :api_key
   end

--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -11,8 +11,8 @@ require 'shippo/api/resource'
 
 module Shippo
   module API
-    @base     = 'https://api.goshippo.com/v1'
-    @version  = 1.0
+    @base     = 'https://api.goshippo.com/'
+    @version  = '' 
     @token    = ''
     @debug    = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false
     @warnings = true

--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -12,7 +12,7 @@ require 'shippo/api/resource'
 module Shippo
   module API
     @base     = 'https://api.goshippo.com/'
-    @version  = '' 
+    @version  = nil
     @token    = ''
     @debug    = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false
     @warnings = true

--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -127,12 +127,13 @@ module Shippo
       end
 
       def setup_headers!(headers)
-        headers.merge!(
+        additional_hash = {
           :accept        => :json,
           :content_type  => :json,
-          :Authorization => "ShippoToken #{token}",
-          :'Shippo-API-Version' => "#{version}"
-        )
+          :Authorization => "ShippoToken #{token}"
+        }
+        additional_hash[:'Shippo-API-Version'] = "Shippo-API-Version #{version}" if version
+        headers.merge!(additional_hash)
       end
 
       def awesome_print_response(e)
@@ -155,7 +156,7 @@ module Shippo
       end
 
       def version
-       ::Shippo::API.version
+        ::Shippo::API.version
       end
 
       def connection_error_message(url, error)

--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -130,7 +130,8 @@ module Shippo
         headers.merge!(
           :accept        => :json,
           :content_type  => :json,
-          :Authorization => "ShippoToken #{token}"
+          :Authorization => "ShippoToken #{token}",
+          :'Shippo-API-Version' => "#{version}"
         )
       end
 
@@ -151,6 +152,10 @@ module Shippo
 
       def token
         ::Shippo::API.token
+      end
+
+      def version
+       ::Shippo::API.version
       end
 
       def connection_error_message(url, error)

--- a/lib/shippo/api/version.rb
+++ b/lib/shippo/api/version.rb
@@ -1,5 +1,5 @@
 module Shippo
   module API
-    VERSION = '2.0.4'
+    VERSION = '2.0.5'
   end
 end

--- a/spec/shippo/api/request_spec.rb
+++ b/spec/shippo/api/request_spec.rb
@@ -7,16 +7,24 @@ RSpec.describe Shippo::API::Request do
   let(:method) { :get }
   let(:uri) { '/some-uri' }
   let(:params) { {} }
-  let(:headers) { {'X-Authorize-Your-Mom' => 'Accepted' } }
+  let(:headers) { {'X-Authorize-Your-Mom' => 'Accepted'} }
 
   let(:api_request) { Shippo::API::Request.new(method: method, uri: uri, params: params, headers: headers) }
   let(:http_response) { RestClient::Response.create(json_string, 200, {}, { response: 'OK' }) }
 
   context '#new' do
-    before do
-
-      expect(RestClient::Request).to receive(:execute).and_return(http_response)
-      api_request.execute
+    before do |example|
+      unless example.metadata[:skip_before]
+        Shippo::API.version = "2.4.5"
+      end
+        expect(RestClient::Request).to receive(:execute).and_return(http_response)
+        api_request.execute
+    end
+    it 'should not include Shippo-API-Version in header if one is not specified', skip_before: true do
+      expect(api_request.headers[:'Shippo-API-Version']).to be_nil
+    end
+    it 'should include Shippo-API-Version in header if one is specified' do
+      expect(api_request.headers[:'Shippo-API-Version']).to eql("Shippo-API-Version 2.4.5")
     end
     it 'should successfully return the response object' do
       expect(api_request.response).to_not be_nil


### PR DESCRIPTION
can send version to use Shippo::API.token instead of Shippo.api_key
