### PR TITLE
Add address validate operation

### DIFF
--- a/lib/shippo/model/address.rb
+++ b/lib/shippo/model/address.rb
@@ -1,5 +1,5 @@
 module Shippo
   class Address < ::Shippo::API::Resource
-    operations :list, :create
+    operations :list, :create, :validate
   end
 end


### PR DESCRIPTION
This was broken with the following commit:
https://github.com/goshippo/shippo-ruby-client/commit/37e22fdc7e214d6774641112ff4f8a80d0d35d92

validate was moved out to a new operation but was not added to address