### PR TITLE
Fixed address validate functionality (endpoint parameterization issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.0.7 release, Jan 2nd, 2017
 - Fixed bug preventing address validation
+- Removed trailing slash from base URL, added spec test to ensure this configuration
 ### 2.0.6 release, Nov 22nd, 2016
 - Fixed bug to send request with correct API version header
 #### 2.0.5 release, Oct 24th, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.0.7 release, Jan 2nd, 2017
+- Fixed bug allowing preventing address validation
 ### 2.0.6 release, Nov 22nd, 2016
 - Fixed bug to send request with correct API version header
 #### 2.0.5 release, Oct 24th, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 2.0.7 release, Jan 2nd, 2017
-- Fixed bug allowing preventing address validation
+- Fixed bug preventing address validation
 ### 2.0.6 release, Nov 22nd, 2016
 - Fixed bug to send request with correct API version header
 #### 2.0.5 release, Oct 24th, 2016

--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -11,7 +11,7 @@ require 'shippo/api/resource'
 
 module Shippo
   module API
-    @base     = 'https://api.goshippo.com/'
+    @base     = 'https://api.goshippo.com'
     @version  = nil
     @token    = ''
     @debug    = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false

--- a/lib/shippo/api/operations/validate.rb
+++ b/lib/shippo/api/operations/validate.rb
@@ -2,8 +2,8 @@ module Shippo
   module API
     module Operations
       module Validate
-        def validate(params={})
-          response = Shippo::API.get("#{url}/validate/", params)
+        def validate(object_id, params={})
+          response = Shippo::API.get("#{url}/#{CGI.escape(object_id)}/validate/", params)
           Shippo::Address.from(response)
         end
       end

--- a/lib/shippo/api/version.rb
+++ b/lib/shippo/api/version.rb
@@ -1,5 +1,5 @@
 module Shippo
   module API
-    VERSION = '2.0.6'
+    VERSION = '2.0.7'
   end
 end

--- a/lib/shippo/model/address.rb
+++ b/lib/shippo/model/address.rb
@@ -1,5 +1,5 @@
 module Shippo
   class Address < ::Shippo::API::Resource
-    operations :list, :create
+    operations :list, :create, :validate
   end
 end

--- a/spec/shippo/api/model/address_spec.rb
+++ b/spec/shippo/api/model/address_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+RSpec.describe Shippo::Address do
+  context 'correctly pluralize address to addresses' do
+    subject { Shippo::Address.url }
+    it { is_expected.to  eql('/addresses') }
+  end
+end

--- a/spec/shippo/api/model/address_spec.rb
+++ b/spec/shippo/api/model/address_spec.rb
@@ -5,11 +5,3 @@ RSpec.describe Shippo::Address do
     it { is_expected.to  eql('/addresses') }
   end
 end
-
-RSpec.describe Shippo::Address do
-  context 'validate' do
-  	v = Shippo::Address.validate('0b1fe132b4d14f5eaee4fd8d480452bc')
-  	puts v.object.id
-  	expect(v.object.id).to eql("c0b8bb8104bd4b67adb4bd57dd886f77")
-  end
-end

--- a/spec/shippo/api/model/address_spec.rb
+++ b/spec/shippo/api/model/address_spec.rb
@@ -5,3 +5,11 @@ RSpec.describe Shippo::Address do
     it { is_expected.to  eql('/addresses') }
   end
 end
+
+RSpec.describe Shippo::Address do
+  context 'validate' do
+  	v = Shippo::Address.validate('0b1fe132b4d14f5eaee4fd8d480452bc')
+  	puts v.object.id
+  	expect(v.object.id).to eql("c0b8bb8104bd4b67adb4bd57dd886f77")
+  end
+end

--- a/spec/shippo/api/request_spec.rb
+++ b/spec/shippo/api/request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Shippo::API::Request do
   let(:method) { :get }
   let(:uri) { '/some-uri' }
   let(:params) { {} }
-  let(:headers) { {'X-Authorize-Your-Mom' => 'Accepted'} }
+  let(:headers) { {'X-Authorize' => 'Accepted'} }
 
   let(:api_request) { Shippo::API::Request.new(method: method, uri: uri, params: params, headers: headers) }
   let(:http_response) { RestClient::Response.create(json_string, 200, {}, { response: 'OK' }) }

--- a/spec/shippo/api_spec.rb
+++ b/spec/shippo/api_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Shippo::API do
     end
   end
 
+  context 'api url definition' do
+    it 'api base url should have no trailing slash' do
+      expect(Shippo::API.base[-1]).not_to eql('/')
+    end
+  end    
+
   context 'api token' do
     before do
       Shippo::API.token = nil


### PR DESCRIPTION
This fixes an issue in which validate address would not work, the URL was malformed. Also added the validate function to the list of supported operations for Address