### PR TITLE
Upgrade required version of Hashie

### DIFF
--- a/shippo.gemspec
+++ b/shippo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '~> 1.8'
   spec.add_dependency 'json', '~> 1.8'
-  spec.add_dependency 'hashie', '~> 3.4'
+  spec.add_dependency 'hashie', '>= 3.5.2'
   spec.add_dependency 'activesupport', '>= 4'
   spec.add_dependency 'awesome_print'
 


### PR DESCRIPTION
fixes https://github.com/goshippo/shippo-ruby-client/issues/47

Looks like the `#disable_warnings` call in `lib/shippo/api/resource.rb` was added in Hashie `3.5.2`(https://github.com/intridea/hashie/pull/395). Gemspec requires Hashie `3.4`.