### PR TITLE
Fix "The property 'object_purpose' is not defined for Shippo::API::Ap…

### DIFF
--- a/lib/shippo/api/api_object.rb
+++ b/lib/shippo/api/api_object.rb
@@ -77,9 +77,10 @@ module Shippo
       PROPS_CATEG      = %i(state status results).freeze
       PROPS_EMAIL      = %i(owner).freeze
       PROPS_TIMED      = %i(created updated).freeze
+      PROPS_PURPOSE    = %i(purpose).freeze
 
       PROPS            = (PROPS_ID + PROPS_EMAIL + PROPS_TIMED + PROPS_CATEG ).flatten.freeze
-      PROPS_AS_IS      = (PROPS_EMAIL + PROPS_ID).freeze
+      PROPS_AS_IS      = (PROPS_EMAIL + PROPS_ID + PROPS_PURPOSE).freeze
 
       def self.setup_property(prop, custom = {})
         property prop, self.mk_opts(prop).merge(custom)


### PR DESCRIPTION
…iObject." error

According to the [docs](https://app.goshippo.com/onboarding/api/shipment) property `object_purpose` is required for successful creating shipments and shipping labels