### PR TITLE
Fixed RestClient warnings

### DIFF
--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -91,7 +91,14 @@ module Shippo
       def shippo_phone_home
         payload     = {}
         request_url = url
-        (method == :get) ? request_url = params_to_url(params, url) : payload = params.to_json
+
+        if method == :get
+          request_url = params_to_url(params, url)
+          payload = nil
+        else
+          payload = params.to_json
+        end
+
         setup_headers!(headers)
         opts = make_opts!(headers, method, payload, request_url)
 

--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -89,16 +89,9 @@ module Shippo
       private
 
       def shippo_phone_home
-        payload     = {}
+        payload     = nil
         request_url = url
-
-        if method == :get
-          request_url = params_to_url(params, url)
-          payload = nil
-        else
-          payload = params.to_json
-        end
-
+        (method == :get) ? request_url = params_to_url(params, url) : payload = params.to_json
         setup_headers!(headers)
         opts = make_opts!(headers, method, payload, request_url)
 


### PR DESCRIPTION
Using a GET request we must not send the payload, otherwise RestClient
will complain because isn't allowed to use content type as JSON and
payload as a Hash.

See https://github.com/rest-client/rest-client/issues/104