### PR TITLE
make RestClient timeouts configurable

### DIFF
--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -11,14 +11,16 @@ require 'shippo/api/resource'
 
 module Shippo
   module API
-    @base     = 'https://api.goshippo.com'
-    @version  = ''
-    @token    = ''
-    @debug    = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false
-    @warnings = true
+    @base         = 'https://api.goshippo.com'
+    @version      = ''
+    @token        = ''
+    @debug        = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false
+    @warnings     = true
+    @open_timeout = 15
+    @read_timeout = 30
 
     class << self
-      attr_accessor :base, :version, :token, :debug, :warnings
+      attr_accessor :base, :version, :token, :debug, :warnings, :open_timeout, :read_timeout
       # @param [Symbol] method One of :get, :put, :post
       # @param [String] uri the URL component after the first slash but before params
       # @param [Hash] params hash of optional parameters to add to the URL

--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -118,8 +118,8 @@ module Shippo
           :method       => method,
           :payload      => payload,
           :url          => url,
-          :open_timeout => 15,
-          :timeout      => 30,
+          :open_timeout => ::Shippo::API.open_timeout,
+          :timeout      => ::Shippo::API.read_timeout,
           :user         => username,
           :password     => password,
           :user_agent   => 'Shippo/v2.0 RubyBindings'

--- a/spec/shippo/api/request_spec.rb
+++ b/spec/shippo/api/request_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Shippo::API::Request do
   let(:uri) { '/some-uri' }
   let(:params) { {} }
   let(:headers) { {'X-Authorize' => 'Accepted'} }
+  let(:open_timeout) { 1 }
+  let(:read_timeout) { 2 }
 
   let(:api_request) { Shippo::API::Request.new(method: method, uri: uri, params: params, headers: headers) }
   let(:net_http) { instance_double('Net::HTTPResponse', {to_hash: {'Status' => ['200 OK']}, code: '200', body: 'foo'}) }
@@ -16,9 +18,11 @@ RSpec.describe Shippo::API::Request do
   context '#new' do
     before do |example|
       unless example.metadata[:skip_before]
+        Shippo::API.open_timeout = open_timeout
+        Shippo::API.read_timeout = read_timeout
         Shippo::API.version = "2017-03-29"
       end
-        expect(RestClient::Request).to receive(:execute).and_return(http_response)
+        allow(RestClient::Request).to receive(:execute).and_return(http_response)
         api_request.execute
     end
     it 'should include Shippo-API-Version in header if one is specified' do
@@ -32,6 +36,12 @@ RSpec.describe Shippo::API::Request do
     end
     it 'should parse the return the body' do
       expect(api_request.parsed_response).to eql(json.to_hash)
+    end
+    it 'should use configured open timeout' do
+      expect(RestClient::Request).to have_received(:execute).with(hash_including(open_timeout: open_timeout))
+    end
+    it 'should use configured read timeout' do
+      expect(RestClient::Request).to have_received(:execute).with(hash_including(timeout: read_timeout))
     end
   end
 

--- a/spec/shippo/api_spec.rb
+++ b/spec/shippo/api_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Shippo::API do
       expect(Shippo::API.read_timeout).to eq(30)
     end
 
-    it 'should set open timeout via Shippo::API.read_timeout=' do
+    it 'should set read timeout via Shippo::API.read_timeout=' do
       read_timeout = 1
       Shippo::API.read_timeout = read_timeout
       expect(Shippo::API.read_timeout).to eql(read_timeout)

--- a/spec/shippo/api_spec.rb
+++ b/spec/shippo/api_spec.rb
@@ -37,6 +37,30 @@ RSpec.describe Shippo::API do
     end
   end
 
+  context 'open timeout' do
+    it 'should have default open timeout of 15' do
+      expect(Shippo::API.open_timeout).to eq(15)
+    end
+
+    it 'should set open timeout via Shippo::API.open_timeout=' do
+      open_timeout = 1
+      Shippo::API.open_timeout = open_timeout
+      expect(Shippo::API.open_timeout).to eql(open_timeout)
+    end
+  end
+
+  context 'read timeout' do
+    it 'should have default read timeout of 30' do
+      expect(Shippo::API.read_timeout).to eq(30)
+    end
+
+    it 'should set open timeout via Shippo::API.read_timeout=' do
+      read_timeout = 1
+      Shippo::API.read_timeout = read_timeout
+      expect(Shippo::API.read_timeout).to eql(read_timeout)
+    end
+  end
+
   context 'colors are no longer defined, but should work silently' do
     let(:string) { 'poopikinks' }
     it 'throws exception when colors are used without require' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,12 @@ RSpec.configure do |config|
   config.before do
     srand 117
   end
+
+  config.around do |example|
+    state = Shippo::API.instance_variables.map { |name| [name, Shippo::API.instance_variable_get(name)] }
+    example.run
+    state.each { |name, value| Shippo::API.instance_variable_set(name, value) }
+  end
 end
 
 Shippo::API.token = 'shippo_test_09e74f332aa839940e6c241bb008157c19428339'


### PR DESCRIPTION
Allowing request timeouts to be configurable seems to be common practice and means better support for users on hosting services like Heroku that have their own time limits for each request. We need Shippo's timeouts to be less than Heroku's (30 seconds), otherwise we're unable to recover and return a graceful response.

Changes:
- move default timeouts up to Shippo::API
- add timeout accessors to Shippo::API
- defer to Shippo::API timeouts when making requests
- specs
   - reset internal Shippo::API state around examples (otherwise defaults are hard to test and per-example changes overwrite global state)
   - use `allow` vs `expect` since the tests themselves assert the expectations, and `allow` enables spying on messages