### PR TITLE
change parcel to parcels - Update basic_shipment_example

### DIFF
--- a/bin/basic_shipment_example
+++ b/bin/basic_shipment_example
@@ -86,7 +86,7 @@ parcel       = {
 
 hash = { :address_from   => address_from,
          :address_to     => address_to,
-         :parcel         => parcel,
+         :parcels         => parcel,
          :async          => false }
 
 begin


### PR DESCRIPTION
based on doc's

```
shipment = Shippo::Shipment.create(
    :address_from => address_from,
    :address_to => address_to,
    :parcels => parcel,
    :async => false
)
```