### PR TITLE
rescue Exception instead of StandardError

### DIFF
--- a/lib/shippo/api/transformers/list.rb
+++ b/lib/shippo/api/transformers/list.rb
@@ -52,8 +52,8 @@ module Shippo
         def detect_type_class(model_name)
           type = model_name.to_s.singularize.camelize
           begin
-            "Shippo::#{type}".constantize
-          rescue Exception
+            "Shippo::#{type}".constantize rescue nil
+          rescue LoadError
             return nil
           end
         end

--- a/lib/shippo/api/transformers/list.rb
+++ b/lib/shippo/api/transformers/list.rb
@@ -51,7 +51,11 @@ module Shippo
 
         def detect_type_class(model_name)
           type = model_name.to_s.singularize.camelize
-          "Shippo::#{type}".constantize rescue nil
+          begin
+            "Shippo::#{type}".constantize
+          rescue Exception
+            return nil
+          end
         end
 
         def detect_type_name(list_key)

--- a/spec/shippo/api/transformers/list_spec.rb
+++ b/spec/shippo/api/transformers/list_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec/mocks'
 require 'shippo/api/transformers/list'
 
 RSpec.describe Shippo::API::Transformers::List do
@@ -30,6 +31,10 @@ RSpec.describe Shippo::API::Transformers::List do
           end
           it 'should be able to match the class name' do
             expect(transform.send(:detect_type_class, 'parcels')).to eql(Shippo::Parcel)
+          end
+          it 'should return nil if String#constantize raise LoadError' do
+            expect_any_instance_of(String).to receive(:constantize).and_raise(LoadError)
+            expect(transform.send(:detect_type_class, 'parcels')).to eql(nil)
           end
           context 'when shipping is created' do
             let(:parcel) { Shippo::Parcel.from(params[:parcels][0]) }


### PR DESCRIPTION
`"Shippo::#{type}".constantize rescue nil` suppose to return `nil` if can't find the constantize. However `ActiveSupport` could raise `LoadError`, see https://github.com/rails/rails/blob/b50ce8d6cfe25711c826b19264c3cb6ddc5b0ec6/activesupport/lib/active_support/dependencies.rb#L550

`rescue nil` only captures `StandardError`, here suppose to capture `NameError`, which is a child class of `StandardError`. But `LoadError` is not a child class of `StandardError` so `Shippo::API::Transformers#detect_type_class` will raise `LoadError` unintentionally.