### PR TITLE
relax json dependency to allow CVE fix in 2.3.0

### DIFF
--- a/shippo.gemspec
+++ b/shippo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata              = { 'shippo_documentation' => 'https://goshippo.com/docs/' }
 
   spec.add_dependency 'rest-client', '>= 2.0', '<2.2'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json', '>= 2.3', '< 3'
   spec.add_dependency 'hashie', '>= 3.5.2'
   spec.add_dependency 'activesupport', '>= 4'
   spec.add_dependency 'awesome_print'


### PR DESCRIPTION
Fixes https://github.com/goshippo/shippo-ruby-client/issues/96