### PR TITLE
Rescue gracefully not found error for detailed responses

### DIFF
--- a/lib/shippo/api/request.rb
+++ b/lib/shippo/api/request.rb
@@ -72,6 +72,14 @@ module Shippo
         rescue ::RestClient::BadRequest => e
           raise Shippo::Exceptions::InvalidInputError.new(e.inspect)
 
+        rescue ::RestClient::NotFound => e
+          if e.respond_to?(:response) && e.response.is_a?(RestClient::Response) && e.response&.body&.include?('detail')
+            awesome_print_response(e) if Shippo::API.debug?
+            raise Shippo::Exceptions::UnsuccessfulResponseError.new('Unsuccessful response with an error', self, e.response)
+          end
+
+          raise Shippo::Exceptions::ConnectionError.new(connection_error_message(url, e))
+
         rescue ::RestClient::Exception => e
           raise Shippo::Exceptions::ConnectionError.new(connection_error_message(url, e))
 


### PR DESCRIPTION
When creating a manifest with invalid data and bad request error should be returned,
GoShippo API instead returns 404 Not found error.
Gem should be able to rescue such errors until proper error will be
returned on server side.