### PR TITLE
adds a model for Orders requests

### DIFF
--- a/lib/shippo/model/order.rb
+++ b/lib/shippo/model/order.rb
@@ -1,0 +1,5 @@
+module Shippo
+  class Order < ::Shippo::API::Resource
+    operations :list, :create
+  end
+end

--- a/spec/shippo/api/model/order_spec.rb
+++ b/spec/shippo/api/model/order_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe 'Shippo::API::Order' do
+  let(:params) do
+    { object_id: 'afa9fa09fa809f98f0a', object_owner: 'shippo@shippotest.com' }
+  end
+
+  let(:order) { Shippo::Order.from(params.dup) }
+
+  describe '#from' do
+    it 'should propertly initialize self and ApiObject' do
+      expect(order).to be_kind_of(Shippo::Order)
+      expect(order.object.owner).to eql('shippo@shippotest.com')
+      expect(order.object.id).to eql('afa9fa09fa809f98f0a')
+    end
+  end
+end


### PR DESCRIPTION
Resolves #100

 - adds an `Order` model with `list` and `create`  operations.
 - adds a basic spec

I followed existing patterns for the spec; but, would like to see additional context testing for confidence sake. Example:

```
context 'given valid parameters' do
  it 'returns an Order object' do
  end
en

context 'given invalid/incomplete parameters' do
  it 'returns an Error object' do
  end
end
```