### PR TITLE
Set default API version to 2018-02-08

### DIFF
--- a/lib/shippo/api.rb
+++ b/lib/shippo/api.rb
@@ -12,7 +12,7 @@ require 'shippo/api/resource'
 module Shippo
   module API
     @base         = 'https://api.goshippo.com'
-    @version      = ''
+    @version      = '2018-02-08'
     @token        = ''
     @debug        = Integer(ENV['SHIPPO_DEBUG'] || 0) > 0 ? true : false
     @warnings     = true


### PR DESCRIPTION
The Shippo API server apparently now requires an API version to be provided, but the Ruby gem doesn't include a default version. Users can get around this by setting it themselves, e.g.:

```
Shippo::API.version = '2018-02-08'
```

The gem is obviously built to interact using a particular version of the API, and this PR makes that version explicit.